### PR TITLE
feat: add Intel DMG build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/RousselPaul/masko-code/releases/latest"><img src="https://img.shields.io/github/v/release/RousselPaul/masko-code?style=flat-square&color=f95d02" alt="Release" /></a>
   <img src="https://img.shields.io/badge/macOS-14.0%2B-black?style=flat-square&logo=apple" alt="macOS 14+" />
-  <img src="https://img.shields.io/badge/Apple%20Silicon-arm64-black?style=flat-square" alt="Apple Silicon" />
+  <img src="https://img.shields.io/badge/Apple%20Silicon%20%2B%20Intel-arm64%20%2F%20x86_64-black?style=flat-square" alt="Apple Silicon + Intel" />
   <img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License" />
 </p>
 
@@ -96,7 +96,7 @@ Click a session in the dashboard or click the mascot overlay to jump to the righ
 ## Requirements
 
 - macOS 14.0+ (Sonoma)
-- Apple Silicon (M1, M2, M3, M4)
+- Apple Silicon (M1, M2, M3, M4) or Intel (x86_64)
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
 
 ## Install
@@ -110,6 +110,12 @@ git clone https://github.com/RousselPaul/masko-code.git
 cd masko-code
 swift build
 swift run
+```
+
+### Intel DMG
+
+```bash
+bash scripts/build-intel-dmg.sh
 ```
 
 ## Project Structure

--- a/scripts/build-intel-dmg.sh
+++ b/scripts/build-intel-dmg.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Build x86_64 app bundle and package DMG
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+APP_NAME="Masko Code"
+BUNDLE_NAME="${APP_NAME}.app"
+ARCH="x86_64"
+CONFIG="release"
+
+BUILD_DIR="$ROOT_DIR/.build"
+BIN_PATH="$BUILD_DIR/${ARCH}-apple-macosx/${CONFIG}/masko-code"
+DIST_DIR="$ROOT_DIR/build/intel"
+APP_DIR="$DIST_DIR/$BUNDLE_NAME"
+DMG_PATH="$DIST_DIR/masko-code-intel.dmg"
+
+rm -rf "$APP_DIR" "$DMG_PATH"
+
+swift build --configuration "$CONFIG" --arch "$ARCH"
+
+mkdir -p "$APP_DIR/Contents/MacOS" "$APP_DIR/Contents/Resources" "$APP_DIR/Contents/Frameworks"
+cp "$BIN_PATH" "$APP_DIR/Contents/MacOS/masko-code"
+cp "$ROOT_DIR/Info.plist" "$APP_DIR/Contents/Info.plist"
+cp -R "$ROOT_DIR/Sources/Resources/"* "$APP_DIR/Contents/Resources/"
+cp -R "$BUILD_DIR/${ARCH}-apple-macosx/${CONFIG}/Sparkle.framework" "$APP_DIR/Contents/Frameworks/"
+
+install_name_tool -add_rpath "@executable_path/../Frameworks" "$APP_DIR/Contents/MacOS/masko-code"
+
+"$ROOT_DIR/scripts/create-dmg.sh" \
+  "$APP_DIR" \
+  "$DMG_PATH" \
+  "$APP_NAME" \
+  "$ROOT_DIR/scripts/dmg-background.py"
+
+echo "Intel DMG ready: $DMG_PATH"


### PR DESCRIPTION
## What

- Update README to mention Apple Silicon + Intel support
- Add Intel DMG build script entry in the build instructions

## Why

- Intel packaging is now supported and should be documented with a clear entry point

## How to test

1. Open README and verify the badge and Requirements text
2. Run `bash scripts/build-intel-dmg.sh` and confirm it produces `build/intel/masko-code-intel.dmg`

## Related issues

Closes #
