### PR TITLE
fix: move IDE detection off main thread in SettingsView

### DIFF
--- a/Sources/Stores/AppStore.swift
+++ b/Sources/Stores/AppStore.swift
@@ -19,6 +19,10 @@ final class AppStore {
     private(set) var isRunning = false
     private var lastReconcileDate: Date = .distantPast
 
+    /// Cached IDE detection results — survives across SettingsView recreations.
+    /// Updated by SettingsView.task and install/uninstall actions.
+    var cachedIDEStatuses: [ExtensionInstaller.IDEStatus] = []
+
     /// Called when a Claude Code event is received — wire to OverlayManager.handleEvent
     var onEventForOverlay: ((ClaudeEvent) -> Void)?
     /// Called when a custom input is received via POST /input

--- a/Sources/Views/Settings/SettingsView.swift
+++ b/Sources/Views/Settings/SettingsView.swift
@@ -336,11 +336,28 @@ struct SettingsView: View {
         .scrollContentBackground(.hidden)
         .background(Constants.lightBackground)
         .navigationTitle("Settings")
-        .onAppear {
+        .task {
+            // Fast, synchronous — safe on main thread
             isHookEnabled = HookInstaller.isRegistered()
             videoCacheSize = VideoCache.shared.cacheSize
-            refreshIDEStatuses()
             portText = String(appStore.localServer.port)
+
+            // Show cached IDE statuses immediately (no flash on repeat visits)
+            if !appStore.cachedIDEStatuses.isEmpty {
+                ideStatuses = appStore.cachedIDEStatuses
+                ideExtensionInstalled = ideStatuses.contains { $0.isInstalled }
+            }
+
+            // Refresh in background — updates cache for next visit
+            let statuses = await withCheckedContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(returning: ExtensionInstaller.allIDEStatuses())
+                }
+            }
+            guard !Task.isCancelled else { return }
+            ideStatuses = statuses
+            ideExtensionInstalled = statuses.contains { $0.isInstalled }
+            appStore.cachedIDEStatuses = statuses
         }
         .alert("Uninstall Masko?", isPresented: $showUninstallConfirm) {
             Button("Cancel", role: .cancel) {}
@@ -405,6 +422,7 @@ struct SettingsView: View {
                 DispatchQueue.main.async {
                     ideStatuses = statuses
                     ideExtensionInstalled = statuses.contains { $0.isInstalled }
+                    appStore.cachedIDEStatuses = statuses
                     ideExtensionEnabled = true
                     extensionBusy = false
                     ExtensionInstaller.triggerPermissionPrompt()
@@ -429,6 +447,7 @@ struct SettingsView: View {
                 DispatchQueue.main.async {
                     ideStatuses = statuses
                     ideExtensionInstalled = statuses.contains { $0.isInstalled }
+                    appStore.cachedIDEStatuses = statuses
                     ideExtensionEnabled = true
                     installingIDE = nil
                     ExtensionInstaller.triggerPermissionPrompt()
@@ -451,6 +470,7 @@ struct SettingsView: View {
             DispatchQueue.main.async {
                 ideStatuses = statuses
                 ideExtensionInstalled = false
+                appStore.cachedIDEStatuses = statuses
                 ideExtensionEnabled = false
                 extensionBusy = false
             }


### PR DESCRIPTION
## What

Fix Settings view freezing when opened from the sidebar.

## Why

`SettingsView.onAppear` calls `ExtensionInstaller.allIDEStatuses()` synchronously on the main thread, spawning up to 10 subprocesses (`/usr/bin/which` per IDE + `--list-extensions` per detected IDE). This blocks the UI for several seconds causing beach ball and frozen UI on every click.

## Changes

- Replace `.onAppear` with `.task` and bridge the blocking subprocess work to `DispatchQueue.global` via `withCheckedContinuation`
- Cache IDE statuses in `AppStore` so repeat visits render instantly from cache while refreshing in the background
- `Task.isCancelled` guard prevents stale writes if the view is dismissed during background work
- Install/uninstall actions update the cache after their work completes

On first visit, the IDE Integration section populates after ~1s. On subsequent visits, it renders instantly from cache.

## What this does NOT change

- `installExtension()` / `uninstallExtension()` — kept their existing `DispatchQueue.global` pattern, just added cache writes
- `refreshIDEStatuses()` — still exists, still used by install/uninstall paths
- No new dependencies or APIs

## Known follow-ups

- `OnboardingView` has the same pattern (`availableIDEs()` called synchronously in step navigation logic and view body)
- `AppStore` Sendable capture warnings (separate concurrency concern)

## How to test

1. `swift build` — no new warnings
2. `swift run` — open the app
3. Click "Settings" in sidebar — opens instantly, no freeze
4. IDE Integration section populates after ~1s on first visit
5. Click another tab, then back to Settings — IDE section appears instantly (cached)
6. Click rapidly between Settings and other tabs — no freeze or beach ball
7. Verify overlay + mascot still work normally

## Related issues

No existing issue.